### PR TITLE
Style guide: Fix `winapi` link

### DIFF
--- a/_posts/2016-08-13-style.md
+++ b/_posts/2016-08-13-style.md
@@ -770,7 +770,7 @@ If you'd like to look for more examples, search the rust repository for
 `is:pr rustfmt`, and you'll see quite a few.
 
 [pink]: https://github.com/ubsan/pinkpp
-[winapi]: https://github.com/retep998/winapi-r://github.com/retep998/winapi-rs
+[winapi]: https://github.com/retep998/winapi-rs
 [Example One]: https://github.com/rust-lang/rust/pull/35614#discussion-diff-74550692
 [Example Two]: https://github.com/rust-lang/rust/pull/34220/files#diff-4f7de8be158a8761fb58795c75249dc9L24
 [Example Three]: https://github.com/rust-lang/rust/pull/34211/files#diff-68d362312a8dd3bf52387ad1b96cbf53L570


### PR DESCRIPTION
In the Standards Rust Style post (`2016-08-13-style.md`), a link to
<https://github.com/retep998/winapi-rs> was entered incorrectly; this
commit fixes this issue.

